### PR TITLE
Skip d-m-p if called in top-level pom.xml

### DIFF
--- a/frontend-js/pom.xml
+++ b/frontend-js/pom.xml
@@ -45,6 +45,7 @@
                     </execution>
                 </executions>
                 <configuration>
+                    <skip>false</skip>
                     <images>
                         <image>
                             <name>${docker.namespace}/${project.artifactId}:${project.version}</name>

--- a/news-server-groovy/pom.xml
+++ b/news-server-groovy/pom.xml
@@ -24,6 +24,9 @@
             <plugin>
                 <groupId>org.jolokia</groupId>
                 <artifactId>docker-maven-plugin</artifactId>
+                <configuration>
+                    <skip>false</skip>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/news-server-java/pom.xml
+++ b/news-server-java/pom.xml
@@ -24,6 +24,9 @@
             <plugin>
                 <groupId>org.jolokia</groupId>
                 <artifactId>docker-maven-plugin</artifactId>
+                <configuration>
+                    <skip>false</skip>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/news-server-js/pom.xml
+++ b/news-server-js/pom.xml
@@ -40,6 +40,9 @@
             <plugin>
                 <groupId>org.jolokia</groupId>
                 <artifactId>docker-maven-plugin</artifactId>
+                <configuration>
+                    <skip>false</skip>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/news-server-rb/pom.xml
+++ b/news-server-rb/pom.xml
@@ -35,6 +35,9 @@
             <plugin>
                 <groupId>org.jolokia</groupId>
                 <artifactId>docker-maven-plugin</artifactId>
+                <configuration>
+                    <skip>false</skip>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/pom.xml
+++ b/pom.xml
@@ -198,6 +198,15 @@
                     <generatedSourcesDirectory>${project.basedir}/src/main/generated</generatedSourcesDirectory>
                 </configuration>
             </plugin>
+
+            <plugin>
+                <groupId>org.jolokia</groupId>
+                <artifactId>docker-maven-plugin</artifactId>
+                <configuration>
+                    <!-- Call it only in subprojects -->
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 


### PR DESCRIPTION
In order to allow a `docker:start` from the top-level so that it descents into the submodules, the execution of d-m-p in the toplevel pom.xml must be switched off with `<skip>true</skip>`. Unfortunately since the submodules inherit from the parent pom.xml, the plugin needs to be reenabled in the child poms again, leading to some duplications (unfortunately I couldn't realize a simple solution involving submodules).

An alternative would be to use a single Maven project for the Docker builds, where all images are configured within a single d-m-p config (within the <images> list).

 BTW, for the setup described above (single project) there will be direct docker compose support soon (i.e. d-m-p picking up a docker compose configuration as well as creating docker compose files from the d-m-p configuration).
